### PR TITLE
Ensure datapackage<1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         'click>=6.7',
         'requests>=2.13.0',
         'ckanapi>=4.0',
-        'datapackage>=0.8.6'],
+        'datapackage>=0.8.6,<1.0'],
     entry_points={
         'console_scripts': [
             'publish = ctdata_ckan_publish.__main__:main',


### PR DESCRIPTION
Hi! Frictionless Data's `datapackage-py` is going to reach v1 release and it could be breaking for some software (we use SemVer). Adding `<1.0` version requirement.